### PR TITLE
Add AI vs AI mode

### DIFF
--- a/aiWorker.js
+++ b/aiWorker.js
@@ -7,7 +7,8 @@ let startTime=0;
 let respectTime=true;
 const TT=new Map();
 // Tune search to respond quicker
-const TIME_LIMIT=2000; // max thinking time in ms
+// Reduced thinking time for quicker play
+const TIME_LIMIT=1000; // max thinking time in ms
 const MAX_DEPTH=6; // maximum search depth
 const MAX_QUIESCE=4; // capture search depth limit
 const KILLER=Array.from({length:16},()=>[null,null]);
@@ -71,6 +72,12 @@ function iterative(state){
 function search(s,depth,alpha,beta,root){
   if(stop||(respectTime && Date.now()-startTime>TIME_LIMIT))return[evalState(s),null];
   if(depth===0)return quiesce(s,alpha,beta,0);
+  if(!root && depth>=2 && !isCheck(s,s.turn)){
+    const ns=clone(s);
+    ns.turn^=1; // null move
+    const score=-search(ns,depth-1-2,-beta,-beta+1,false)[0];
+    if(score>=beta) return [beta,null];
+  }
   const key=hashState(s);
   const tt=TT.get(key);
   if(tt && tt.depth>=depth)return[tt.score,tt.move];

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <div id="board" class="board"></div>
     <div id="log" class="log"></div>
   </div>
-  <div class="handBox"><span class="handLabel">先手（あなた）持ち駒:</span><div id="hand0" class="hand"></div></div>
+  <div class="handBox"><span class="handLabel">先手（コンピュータ）持ち駒:</span><div id="hand0" class="hand"></div></div>
   <div id="info">
     <span id="turn">先手番</span>
     <span id="moveCount">手数:0</span>

--- a/shogi.js
+++ b/shogi.js
@@ -5,7 +5,9 @@ const PIECE_NAMES={
 const PROMOTABLE={P:1,L:1,N:1,S:1,B:1,R:1};
 const PROMOTE={'P':'+P','L':'+L','N':'+N','S':'+S','B':'+B','R':'+R'};
 const UNPROMOTE={'+P':'P','+L':'L','+N':'N','+S':'S','+B':'B','+R':'R'};
-const HUMAN=0; // player side
+// Both sides are controlled by the AI
+const HUMAN=-1; // no human player
+const AI_PLAYERS=[true,true];
 function initialState(){
   const b=Array(81).fill(null);
   const s=['L','N','S','G','K','G','S','N','L',null,'R',null,null,null,null,null,'B',null];
@@ -74,6 +76,12 @@ function stopThinking(ms){
   clearInterval(timerId);
   statusEl.textContent='思考時間:'+ (ms/1000).toFixed(1)+'秒';
 }
+function maybeAIMove(){
+  if(AI_PLAYERS[state.turn]){
+    startThinking();
+    worker.postMessage({type:'start',state:serialize(state)});
+  }
+}
 function selectFrom(i){
   if(state.turn!==HUMAN)return;
   const p=state.board[i];
@@ -122,7 +130,7 @@ function renderLog(){
 }
 
 function addLog(player,m){
-  logs.push((player===HUMAN?'先手:':'後手:')+moveToString(m));
+  logs.push((player===0?'先手:':'後手:')+moveToString(m));
   renderLog();
 }
 boardEl.onclick=e=>{
@@ -157,12 +165,12 @@ function resetGame(){
 }
 document.getElementById('reset').onclick=resetGame;
 function playMove(m){
+  const player=state.turn;
   applyMove(state,m);
-  addLog(HUMAN,m);
+  addLog(player,m);
   render();
   state.history.push(m);
-  startThinking();
-  worker.postMessage({type:'start',state:serialize(state)});
+  maybeAIMove();
 }
 function inZone(color,idx){
   const y=8-Math.floor(idx/9);
@@ -295,17 +303,20 @@ function serialize(s){
 }
 
 render();
+maybeAIMove();
 const worker=new Worker('aiWorker.js');
 worker.onmessage=e=>{
   if(ignore){ignore=false;return;}
   const {move,time}=e.data;
   stopThinking(time);
   if(!move){
-    statusEl.textContent='後手の負けです';
+    statusEl.textContent=(state.turn===0?'先手':'後手')+'の負けです';
     return;
   }
+  const player=state.turn;
   applyMove(state,move);
-  addLog(1,move);
+  addLog(player,move);
   state.history.push(move);
   render();
+  maybeAIMove();
 };


### PR DESCRIPTION
## Summary
- support an AI vs AI mode by letting both sides use the worker
- show "computer" for both hands in `index.html`
- optimize AI search with a shorter thinking time and null move pruning

## Testing
- `python3 test`

------
https://chatgpt.com/codex/tasks/task_e_686e06287f608325b0e1f0583c8b1cc1