### PR TITLE
Add AI-vs-AI mode and faster search

### DIFF
--- a/aiWorker.js
+++ b/aiWorker.js
@@ -10,6 +10,7 @@ const TT=new Map();
 const TIME_LIMIT=2000; // max thinking time in ms
 const MAX_DEPTH=6; // maximum search depth
 const MAX_QUIESCE=4; // capture search depth limit
+const NULL_MOVE_R=2; // reduction for null move pruning
 const KILLER=Array.from({length:16},()=>[null,null]);
 const HISTORY={};
 
@@ -74,6 +75,16 @@ function search(s,depth,alpha,beta,root){
   const key=hashState(s);
   const tt=TT.get(key);
   if(tt && tt.depth>=depth)return[tt.score,tt.move];
+  // Null move pruning to skip unpromising branches
+  if(!root && depth>2 && !isCheck(s,s.turn)){
+    const ns=clone(s);
+    ns.turn^=1; // pass move
+    const [v]=search(ns,depth-1-NULL_MOVE_R,-beta,-beta+1,false);
+    if(-v>=beta){
+      TT.set(key,{depth,score:beta,move:null});
+      return[beta,null];
+    }
+  }
   const moves=orderMoves(generateLegalMoves(s,s.turn),depth);
   let best=null;
   let pv=false;

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
     <span id="moveCount">手数:0</span>
     <button id="undo">待った</button>
     <button id="reset">リセット</button>
+    <button id="toggle">AI\u5bfeAI</button>
     <span id="status"></span>
   </div>
 </div>

--- a/shogi.js
+++ b/shogi.js
@@ -5,7 +5,8 @@ const PIECE_NAMES={
 const PROMOTABLE={P:1,L:1,N:1,S:1,B:1,R:1};
 const PROMOTE={'P':'+P','L':'+L','N':'+N','S':'+S','B':'+B','R':'+R'};
 const UNPROMOTE={'+P':'P','+L':'L','+N':'N','+S':'S','+B':'B','+R':'R'};
-const HUMAN=0; // player side
+let HUMAN=0; // player side, -1 when AI vs AI
+let aiMode=false;
 function initialState(){
   const b=Array(81).fill(null);
   const s=['L','N','S','G','K','G','S','N','L',null,'R',null,null,null,null,null,'B',null];
@@ -122,7 +123,7 @@ function renderLog(){
 }
 
 function addLog(player,m){
-  logs.push((player===HUMAN?'先手:':'後手:')+moveToString(m));
+  logs.push((player===0?'先手:':'後手:')+moveToString(m));
   renderLog();
 }
 boardEl.onclick=e=>{
@@ -154,15 +155,36 @@ function resetGame(){
   logs=[];
   render();
   renderLog();
+  if(aiMode && state.turn!==HUMAN){
+    startThinking();
+    worker.postMessage({type:'start',state:serialize(state)});
+  }
 }
 document.getElementById('reset').onclick=resetGame;
+document.getElementById('toggle').onclick=()=>{
+  aiMode=!aiMode;
+  const btn=document.getElementById('toggle');
+  if(aiMode){
+    HUMAN=-1;
+    btn.textContent='人間対AI';
+    if(state.turn!==HUMAN){
+      startThinking();
+      worker.postMessage({type:'start',state:serialize(state)});
+    }
+  }else{
+    HUMAN=0;
+    btn.textContent='AI対AI';
+  }
+};
 function playMove(m){
   applyMove(state,m);
   addLog(HUMAN,m);
   render();
   state.history.push(m);
-  startThinking();
-  worker.postMessage({type:'start',state:serialize(state)});
+  if(state.turn!==HUMAN){
+    startThinking();
+    worker.postMessage({type:'start',state:serialize(state)});
+  }
 }
 function inZone(color,idx){
   const y=8-Math.floor(idx/9);
@@ -305,7 +327,11 @@ worker.onmessage=e=>{
     return;
   }
   applyMove(state,move);
-  addLog(1,move);
+  addLog(state.turn^1,move);
   state.history.push(move);
   render();
+  if(state.turn!==HUMAN){
+    startThinking();
+    worker.postMessage({type:'start',state:serialize(state)});
+  }
 };


### PR DESCRIPTION
## Summary
- add button to toggle AI vs AI mode
- implement toggle logic and auto-play in `shogi.js`
- improve search with null move pruning

## Testing
- `python3 test`


------
https://chatgpt.com/codex/tasks/task_e_686e06287f608325b0e1f0583c8b1cc1