### PR TITLE
Implement AI vs AI mode

### DIFF
--- a/aiWorker.js
+++ b/aiWorker.js
@@ -7,7 +7,8 @@ let startTime=0;
 let respectTime=true;
 const TT=new Map();
 // Tune search to respond quicker
-const TIME_LIMIT=2000; // max thinking time in ms
+// Reduce thinking time and keep depth
+const TIME_LIMIT=1500; // max thinking time in ms
 const MAX_DEPTH=6; // maximum search depth
 const MAX_QUIESCE=4; // capture search depth limit
 const KILLER=Array.from({length:16},()=>[null,null]);
@@ -71,6 +72,13 @@ function iterative(state){
 function search(s,depth,alpha,beta,root){
   if(stop||(respectTime && Date.now()-startTime>TIME_LIMIT))return[evalState(s),null];
   if(depth===0)return quiesce(s,alpha,beta,0);
+  // null-move pruning for speed
+  if(!root && depth>=3 && !isCheck(s,s.turn)){
+    const ns=clone(s);
+    ns.turn^=1;
+    const score=-search(ns,depth-3,-beta,-beta+1,false)[0];
+    if(score>=beta)return[beta,null];
+  }
   const key=hashState(s);
   const tt=TT.get(key);
   if(tt && tt.depth>=depth)return[tt.score,tt.move];

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
     <span id="moveCount">手数:0</span>
     <button id="undo">待った</button>
     <button id="reset">リセット</button>
+    <button id="auto">AI対局</button>
     <span id="status"></span>
   </div>
 </div>

--- a/shogi.js
+++ b/shogi.js
@@ -27,6 +27,7 @@ const logEl=document.getElementById('log');
 let logs=[];
 let timerId=null;
 let thinkStart=0;
+let autoPlay=false;
 function render(){
   boardEl.innerHTML='';
   for(let i=0;i<81;i++){
@@ -75,7 +76,7 @@ function stopThinking(ms){
   statusEl.textContent='思考時間:'+ (ms/1000).toFixed(1)+'秒';
 }
 function selectFrom(i){
-  if(state.turn!==HUMAN)return;
+  if(autoPlay || state.turn!==HUMAN)return;
   const p=state.board[i];
   if(!p||p.c!==HUMAN)return;
   selected={from:i,piece:p};
@@ -83,7 +84,7 @@ function selectFrom(i){
   highlight();
 }
 function selectHand(type,c){
-  if(c!==HUMAN||state.turn!==HUMAN)return;
+  if(autoPlay || c!==HUMAN||state.turn!==HUMAN)return;
   selected={from:-1,type};
   legal=generateLegalMoves(state,c).filter(m=>m.drop===type);
   highlight();
@@ -126,7 +127,7 @@ function addLog(player,m){
   renderLog();
 }
 boardEl.onclick=e=>{
-  if(state.turn!==HUMAN)return;
+  if(autoPlay || state.turn!==HUMAN)return;
   const idx=Number(e.target.closest('.cell')?.dataset.index);
   if(selected){
     const mv=legal.find(m=>m.to===idx);
@@ -154,8 +155,18 @@ function resetGame(){
   logs=[];
   render();
   renderLog();
+  if(autoPlay) aiMove();
 }
 document.getElementById('reset').onclick=resetGame;
+document.getElementById('auto').onclick=()=>{
+  autoPlay=!autoPlay;
+  document.getElementById('auto').textContent=autoPlay?'停止':'AI対局';
+  if(autoPlay) aiMove();
+};
+function aiMove(){
+  startThinking();
+  worker.postMessage({type:'start',state:serialize(state)});
+}
 function playMove(m){
   applyMove(state,m);
   addLog(HUMAN,m);
@@ -308,4 +319,5 @@ worker.onmessage=e=>{
   addLog(1,move);
   state.history.push(move);
   render();
+  if(autoPlay) aiMove();
 };


### PR DESCRIPTION
## Summary
- add AI対局 button to start AI vs AI
- allow toggling autoplay in shogi.js
- start AI moves automatically after each move when autoplay is on
- add null-move pruning and decrease AI think time

## Testing
- `python3 test`


------
https://chatgpt.com/codex/tasks/task_e_686e06287f608325b0e1f0583c8b1cc1