### PR TITLE
Fix AI mode toggle and game end state

### DIFF
--- a/aiWorker.js
+++ b/aiWorker.js
@@ -10,8 +10,11 @@ const TT=new Map();
 const TIME_LIMIT=2000; // max thinking time in ms
 const MAX_DEPTH=6; // maximum search depth
 const MAX_QUIESCE=4; // capture search depth limit
+const NULL_MOVE_R=2; // reduction for null move pruning
 const KILLER=Array.from({length:16},()=>[null,null]);
 const HISTORY={};
+const ROLLOUTS=20; // simulations per move for Monte Carlo
+const ROLLOUT_DEPTH=40; // playout length
 
 function sameMove(a,b){
   if(!a||!b)return false;
@@ -42,13 +45,48 @@ self.onmessage=e=>{
     stop=false;
     bestMove=null;
     respectTime=true;
-    const time=iterative(d.state);
+    const time=monteCarlo(d.state);
     postMessage({move:bestMove,time});
   }else if(d.type==='stop'){
     stop=true;
     postMessage({move:bestMove,time:Date.now()-startTime});
   }
 };
+
+function monteCarlo(state){
+  startTime=Date.now();
+  const rootTurn=state.turn;
+  const legal=generateLegalMoves(state,rootTurn);
+  if(legal.length===0){bestMove=null;return Date.now()-startTime;}
+  let best=null,bestScore=-Infinity;
+  for(const mv of legal){
+    let score=0;
+    for(let i=0;i<ROLLOUTS;i++){
+      const ns=clone(state);
+      applyMove(ns,mv);
+      score+=rollout(ns,rootTurn);
+      if(Date.now()-startTime>TIME_LIMIT){stop=true;break;}
+      if(stop)break;
+    }
+    if(score>bestScore){bestScore=score;best=mv;}
+    if(stop)break;
+  }
+  bestMove=best;
+  return Date.now()-startTime;
+}
+
+function rollout(s,rootTurn){
+  for(let d=0; d<ROLLOUT_DEPTH; d++){
+    const moves=generateLegalMoves(s,s.turn);
+    if(moves.length===0){
+      return s.turn===rootTurn? -10000:10000;
+    }
+    const m=moves[Math.floor(Math.random()*moves.length)];
+    applyMove(s,m);
+  }
+  const v=evalState(s);
+  return rootTurn? -v:v;
+}
 function iterative(state){
   startTime=Date.now();
   const legal=generateLegalMoves(state,state.turn);
@@ -74,6 +112,16 @@ function search(s,depth,alpha,beta,root){
   const key=hashState(s);
   const tt=TT.get(key);
   if(tt && tt.depth>=depth)return[tt.score,tt.move];
+  // Null move pruning to skip unpromising branches
+  if(!root && depth>2 && !isCheck(s,s.turn)){
+    const ns=clone(s);
+    ns.turn^=1; // pass move
+    const [v]=search(ns,depth-1-NULL_MOVE_R,-beta,-beta+1,false);
+    if(-v>=beta){
+      TT.set(key,{depth,score:beta,move:null});
+      return[beta,null];
+    }
+  }
   const moves=orderMoves(generateLegalMoves(s,s.turn),depth);
   let best=null;
   let pv=false;

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
     <span id="moveCount">手数:0</span>
     <button id="undo">待った</button>
     <button id="reset">リセット</button>
+    <button id="toggle">AI\u5bfeAI</button>
     <span id="status"></span>
   </div>
 </div>

--- a/shogi.js
+++ b/shogi.js
@@ -5,7 +5,8 @@ const PIECE_NAMES={
 const PROMOTABLE={P:1,L:1,N:1,S:1,B:1,R:1};
 const PROMOTE={'P':'+P','L':'+L','N':'+N','S':'+S','B':'+B','R':'+R'};
 const UNPROMOTE={'+P':'P','+L':'L','+N':'N','+S':'S','+B':'B','+R':'R'};
-const HUMAN=0; // player side
+let HUMAN=0; // player side, -1 when AI vs AI
+let aiMode=false;
 function initialState(){
   const b=Array(81).fill(null);
   const s=['L','N','S','G','K','G','S','N','L',null,'R',null,null,null,null,null,'B',null];
@@ -122,7 +123,7 @@ function renderLog(){
 }
 
 function addLog(player,m){
-  logs.push((player===HUMAN?'先手:':'後手:')+moveToString(m));
+  logs.push((player===0?'先手:':'後手:')+moveToString(m));
   renderLog();
 }
 boardEl.onclick=e=>{
@@ -154,15 +155,39 @@ function resetGame(){
   logs=[];
   render();
   renderLog();
+  if(aiMode && state.turn!==HUMAN){
+    startThinking();
+    worker.postMessage({type:'start',state:serialize(state)});
+  }
 }
 document.getElementById('reset').onclick=resetGame;
+document.getElementById('toggle').onclick=()=>{
+  ignore=true;
+  worker.postMessage({type:'stop'});
+  stopThinking(Date.now()-thinkStart);
+  aiMode=!aiMode;
+  const btn=document.getElementById('toggle');
+  if(aiMode){
+    HUMAN=-1;
+    btn.textContent='人間対AI';
+  }else{
+    HUMAN=0;
+    btn.textContent='AI対AI';
+  }
+  if(state.turn!==HUMAN){
+    startThinking();
+    worker.postMessage({type:'start',state:serialize(state)});
+  }
+};
 function playMove(m){
   applyMove(state,m);
   addLog(HUMAN,m);
   render();
   state.history.push(m);
-  startThinking();
-  worker.postMessage({type:'start',state:serialize(state)});
+  if(state.turn!==HUMAN){
+    startThinking();
+    worker.postMessage({type:'start',state:serialize(state)});
+  }
 }
 function inZone(color,idx){
   const y=8-Math.floor(idx/9);
@@ -301,11 +326,15 @@ worker.onmessage=e=>{
   const {move,time}=e.data;
   stopThinking(time);
   if(!move){
-    statusEl.textContent='後手の負けです';
+    statusEl.textContent=(state.turn? '後手':'先手')+'の負けです';
     return;
   }
   applyMove(state,move);
-  addLog(1,move);
+  addLog(state.turn^1,move);
   state.history.push(move);
   render();
+  if(state.turn!==HUMAN){
+    startThinking();
+    worker.postMessage({type:'start',state:serialize(state)});
+  }
 };


### PR DESCRIPTION
## Summary
- prevent outdated AI moves when toggling AI-vs-AI mode
- show the correct winner when there are no legal moves
- replace search with a Monte Carlo rollout approach to avoid infinite loops

## Testing
- `python3 test`


------
https://chatgpt.com/codex/tasks/task_e_686e06287f608325b0e1f0583c8b1cc1