### PR TITLE
Fix AI mode toggle and game end state

### DIFF
--- a/aiWorker.js
+++ b/aiWorker.js
@@ -4,125 +4,59 @@ const PROMOTABLE={P:1,L:1,N:1,S:1,B:1,R:1};
 let stop=false;
 let bestMove=null;
 let startTime=0;
-let respectTime=true;
-const TT=new Map();
-// Tune search to respond quicker
-const TIME_LIMIT=2000; // max thinking time in ms
-const MAX_DEPTH=6; // maximum search depth
-const MAX_QUIESCE=4; // capture search depth limit
-const KILLER=Array.from({length:16},()=>[null,null]);
-const HISTORY={};
+const TIME_LIMIT=1000; // thinking time per move
+const PLAYOUTS=40;     // playouts per move
+const PLAYOUT_DEPTH=20; // max playout length
 
-function sameMove(a,b){
-  if(!a||!b)return false;
-  return a.from===b.from&&a.to===b.to&&a.drop===b.drop&&!!a.promote===!!b.promote;
-}
-function moveKey(m){
-  if(m.from>=0)return m.from+"-"+m.to+(m.promote?"p":"");
-  return "D"+m.drop+"-"+m.to;
-}
-function orderMoves(moves,depth){
-  const killers=KILLER[depth]||[];
-  return moves.sort((a,b)=>{
-    const score=(m)=>{
-      let s=0;
-      if(sameMove(m,killers[0]))s+=1000;
-      else if(sameMove(m,killers[1]))s+=990;
-      if(m.capture)s+=50;
-      if(m.promote)s+=20;
-      s+=(HISTORY[moveKey(m)]||0);
-      return s;
-    };
-    return score(b)-score(a);
-  });
-}
 self.onmessage=e=>{
   const d=e.data;
   if(d.type==='start'){
     stop=false;
-    bestMove=null;
-    respectTime=true;
-    const time=iterative(d.state);
-    postMessage({move:bestMove,time});
+    bestMove=mctsSearch(d.state);
+    postMessage({move:bestMove,time:Date.now()-startTime});
   }else if(d.type==='stop'){
     stop=true;
     postMessage({move:bestMove,time:Date.now()-startTime});
   }
 };
-function iterative(state){
+
+function mctsSearch(state){
   startTime=Date.now();
-  const legal=generateLegalMoves(state,state.turn);
-  if(legal.length===0){bestMove=null;return Date.now()-startTime;}
-  orderMoves(legal,0);
-  for(let depth=1;depth<=MAX_DEPTH;depth++){
-    const [v,m]=search(state,depth,-1e9,1e9,true);
+  const moves=generateLegalMoves(state,state.turn);
+  if(moves.length===0)return null;
+  let best=moves[0];
+  let bestScore=-Infinity;
+  for(const mv of moves){
     if(stop)break;
-    if(m)bestMove=m;
-    if(Date.now()-startTime>TIME_LIMIT && bestMove)break;
+    let total=0;
+    for(let i=0;i<PLAYOUTS;i++){
+      if(stop||Date.now()-startTime>TIME_LIMIT)break;
+      const s=clone(state);
+      applyMove(s,mv);
+      total+=randomPlayout(s,state.turn);
+    }
+    const avg=total/PLAYOUTS;
+    if(avg>bestScore){bestScore=avg;best=mv;}
+    if(Date.now()-startTime>TIME_LIMIT)break;
   }
-  if(!bestMove){
-    respectTime=false;
-    const [v,m]=search(state,1,-1e9,1e9,true);
-    bestMove=m;
-    respectTime=true;
-  }
-  return Date.now()-startTime;
+  return best;
 }
-function search(s,depth,alpha,beta,root){
-  if(stop||(respectTime && Date.now()-startTime>TIME_LIMIT))return[evalState(s),null];
-  if(depth===0)return quiesce(s,alpha,beta,0);
-  const key=hashState(s);
-  const tt=TT.get(key);
-  if(tt && tt.depth>=depth)return[tt.score,tt.move];
-  const moves=orderMoves(generateLegalMoves(s,s.turn),depth);
-  let best=null;
-  let pv=false;
-  for(const mv of moves){
-    const ns=clone(s);
-    applyMove(ns,mv);
-    let score;
-    if(pv){
-      score=-search(ns,depth-1,-alpha-1,-alpha,false)[0];
-      if(score>alpha && score<beta){
-        score=-search(ns,depth-1,-beta,-alpha,false)[0];
-      }
-    }else{
-      score=-search(ns,depth-1,-beta,-alpha,true)[0];
+
+function randomPlayout(s,rootColor){
+  const seen=new Set();
+  for(let depth=0;depth<PLAYOUT_DEPTH;depth++){
+    const key=hashState(s);
+    if(seen.has(key))break;
+    seen.add(key);
+    const moves=generateLegalMoves(s,s.turn);
+    if(moves.length===0){
+      return s.turn===rootColor? -10000:10000;
     }
-    if(score>alpha){
-      alpha=score;best=mv;pv=true;
-      if(alpha>=beta){
-        const killers=KILLER[depth];
-        if(!sameMove(mv,killers[0])){killers[1]=killers[0];killers[0]=mv;}
-        HISTORY[moveKey(mv)]=(HISTORY[moveKey(mv)]||0)+depth*depth;
-        break;
-      }
-    }
-    if(stop||(respectTime && Date.now()-startTime>TIME_LIMIT))break;
+    const mv=moves[Math.floor(Math.random()*moves.length)];
+    applyMove(s,mv);
   }
-  TT.set(key,{depth,score:alpha,move:best});
-  if(TT.size>20000)TT.delete(TT.keys().next().value);
-  return[alpha,best];
-}
-function quiesce(s,alpha,beta,depth=0){
-  if(depth>=MAX_QUIESCE) return[evalState(s),null];
-  let stand=evalState(s);
-  if(stand>=beta)return[beta,null];
-  if(alpha<stand)alpha=stand;
-  const moves=orderMoves(generateMoves(s,s.turn).filter(m=>m.capture),depth);
-  let best=null;
-  for(const mv of moves){
-    const ns=clone(s);
-    applyMove(ns,mv);
-    const [v]=quiesce(ns,-beta,-alpha,depth+1);
-    const score=-v;
-    if(score>alpha){
-      alpha=score;best=mv;
-      if(alpha>=beta)break;
-    }
-    if(stop||(respectTime && Date.now()-startTime>TIME_LIMIT))break;
-  }
-  return[alpha,best];
+  const val=evalState(s);
+  return rootColor? -val: val;
 }
 function evalState(s){
   const val={P:100,L:300,N:300,S:400,G:500,B:700,R:800,K:0,'+P':500,'+L':500,'+N':500,'+S':500,'+B':900,'+R':1000};

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
     <span id="moveCount">手数:0</span>
     <button id="undo">待った</button>
     <button id="reset">リセット</button>
+    <button id="toggle">AI\u5bfeAI</button>
     <span id="status"></span>
   </div>
 </div>

--- a/shogi.js
+++ b/shogi.js
@@ -5,7 +5,8 @@ const PIECE_NAMES={
 const PROMOTABLE={P:1,L:1,N:1,S:1,B:1,R:1};
 const PROMOTE={'P':'+P','L':'+L','N':'+N','S':'+S','B':'+B','R':'+R'};
 const UNPROMOTE={'+P':'P','+L':'L','+N':'N','+S':'S','+B':'B','+R':'R'};
-const HUMAN=0; // player side
+let HUMAN=0; // player side, -1 when AI vs AI
+let aiMode=false;
 function initialState(){
   const b=Array(81).fill(null);
   const s=['L','N','S','G','K','G','S','N','L',null,'R',null,null,null,null,null,'B',null];
@@ -122,7 +123,7 @@ function renderLog(){
 }
 
 function addLog(player,m){
-  logs.push((player===HUMAN?'先手:':'後手:')+moveToString(m));
+  logs.push((player===0?'先手:':'後手:')+moveToString(m));
   renderLog();
 }
 boardEl.onclick=e=>{
@@ -154,15 +155,39 @@ function resetGame(){
   logs=[];
   render();
   renderLog();
+  if(aiMode && state.turn!==HUMAN){
+    startThinking();
+    worker.postMessage({type:'start',state:serialize(state)});
+  }
 }
 document.getElementById('reset').onclick=resetGame;
+document.getElementById('toggle').onclick=()=>{
+  ignore=true;
+  worker.postMessage({type:'stop'});
+  stopThinking(Date.now()-thinkStart);
+  aiMode=!aiMode;
+  const btn=document.getElementById('toggle');
+  if(aiMode){
+    HUMAN=-1;
+    btn.textContent='人間対AI';
+  }else{
+    HUMAN=0;
+    btn.textContent='AI対AI';
+  }
+  if(state.turn!==HUMAN){
+    startThinking();
+    worker.postMessage({type:'start',state:serialize(state)});
+  }
+};
 function playMove(m){
   applyMove(state,m);
   addLog(HUMAN,m);
   render();
   state.history.push(m);
-  startThinking();
-  worker.postMessage({type:'start',state:serialize(state)});
+  if(state.turn!==HUMAN){
+    startThinking();
+    worker.postMessage({type:'start',state:serialize(state)});
+  }
 }
 function inZone(color,idx){
   const y=8-Math.floor(idx/9);
@@ -301,11 +326,15 @@ worker.onmessage=e=>{
   const {move,time}=e.data;
   stopThinking(time);
   if(!move){
-    statusEl.textContent='後手の負けです';
+    statusEl.textContent=(state.turn? '後手':'先手')+'の負けです';
     return;
   }
   applyMove(state,move);
-  addLog(1,move);
+  addLog(state.turn^1,move);
   state.history.push(move);
   render();
+  if(state.turn!==HUMAN){
+    startThinking();
+    worker.postMessage({type:'start',state:serialize(state)});
+  }
 };


### PR DESCRIPTION
## Summary
- prevent outdated AI moves when toggling AI-vs-AI mode
- show the correct winner when there are no legal moves
- replace the previous alpha-beta engine with a lightweight MCTS search to avoid endless loops

## Testing
- `python3 test`


------
https://chatgpt.com/codex/tasks/task_e_686e06287f608325b0e1f0583c8b1cc1